### PR TITLE
helm-grepint--prepare-args: add “--” separator before search args

### DIFF
--- a/helm-grepint.el
+++ b/helm-grepint.el
@@ -274,7 +274,7 @@ or property was not found."
 		  (if (equal ccase 'case-insensitive)
 		      (append args (list igncasearg))
 		    args))))))
-    (append args (list searchstr))))
+    (append args '("--") (list searchstr))))
 
 (defun helm-grepint-run-command (&rest plist)
   "Run a grep command from PLIST.


### PR DESCRIPTION
This prevents a search argument starting with - from being interpreted as a
command line option.