### PR TITLE
Convert the command line handling to support templates

### DIFF
--- a/helm-grepint.el
+++ b/helm-grepint.el
@@ -349,9 +349,10 @@ Returns a list of (file line contents) or nil if the line could not be parsed."
   "Jump to line in a file described by a grep -line CANDIDATE."
   (run-hooks 'helm-grepint-grep-jump-pre-hook)
   (let ((items (helm-grepint-grep-parse-line candidate)))
-    (with-helm-default-directory (helm-default-directory)
+    (when items
+      (with-helm-default-directory (helm-default-directory)
 	(find-file (nth 0 items))
-      (helm-goto-line (string-to-number (nth 1 items)))))
+	(helm-goto-line (string-to-number (nth 1 items))))))
   (run-hooks 'helm-grepint-grep-jump-post-hook))
 
 (defun helm-grepint-grep-action-mode (candidate)


### PR DESCRIPTION
Previously the arguments for the greps were just pasted together. It was assumed that the final argument is the pattern that should be searched. Also, the `--ignore-case` was also just pasted to the command line just before the pattern.

This changes the behaviour in such a way that the string in the `:arguments` property can contain strings `":ignore-case-argument"` and `":seach-pattern"`, which are replaced before running the command with `--ignore-case` and the helm search pattern, respectively. Additionally, if those strings are not found in the `:arguments`, they are pasted at the end of the command line, just as before.

This also fixes the error that would happen if RET is pressed where no lines are not found during grepping.