### PR TITLE
Fix escaping double-quotes when constructing the grep command

### DIFF
--- a/helm-grepint.el
+++ b/helm-grepint.el
@@ -320,7 +320,7 @@ used as is."
     (when cmd
       (setq helm-grepint-current-command
 	    (mapconcat (lambda (s)
-			 (concat "\"" (replace-regexp-in-string "\"" "\\\"" s) "\""))
+			 (concat "\"" (replace-regexp-in-string "\"" "\\\"" s nil 'literal) "\""))
 		       (append (list cmd) args) " "))
       (setq proc (apply 'start-process "helm-grepint" nil
 			(append (list cmd) args)))


### PR DESCRIPTION
This caused the following error when double-quotes were given in the
helm-pattern:

(error "Candidates function ‘helm-grepint-grep-process’ should run a process")

When debugging is enabled, the underlying error is:

"Invalid use of `\\` in replacement text"

in (replace-match). I.e. regular expression replacer doesn't accept the
replacement string. The solution is to dumb it down to a simple replace (as
nothing fancier is needed in this case).

Fixes #16.